### PR TITLE
Build with locally provided boost.1.68.0; adjust docs accordingly

### DIFF
--- a/ecoin/doc/build-linux.txt
+++ b/ecoin/doc/build-linux.txt
@@ -15,7 +15,7 @@ All of the commands should be executed in a shell.
 
   + Official:
 
-	git clone http://code.03c8.net/epsylon/ecoin
+	git clone https://code.03c8.net/epsylon/ecoin
 
   + Mirror:
 
@@ -30,6 +30,7 @@ All of the commands should be executed in a shell.
 (0.) Version libraries:
 
     - Libboost -> source code 1.68 provided at: src/boost_1_68_0
+    *IMPORTANT*: This version of boost requires python 2.7 for successful build.    Make sure you have that python version available before, or the build will fail (e.g. by using pyenv to install it).
 
 (1.) Install dependencies:
 
@@ -48,6 +49,10 @@ All of the commands should be executed in a shell.
     An executable named 'ecoind' will be built.
     
     Now you can launch: ./ecoind to run your ECOin server.
+    *IMPORTANT NOTE*:
+    Currently (and as long as this software only supports boost_1.68.0), launch ecoind like this: 
+    `LD_LIBRARY_PATH=./boost_1_68_0/build/lib/ ./ecoind`
+    Alternatively, copy the libraries built during make from boost_1_68_0/build/lib to the system library folder (e.g. /lib/x86_64-linux-gnu)
 
 ------------------------------
 

--- a/ecoin/src/makefile.linux
+++ b/ecoin/src/makefile.linux
@@ -6,9 +6,10 @@ USE_IPV6:=0
 LINK:=$(CXX)
 ARCH:=$(system lscpu | head -n 1 | awk '{print $2}')
 
-BOOST_DIR := $(CURDIR)/src/boost_1_68_0
-BOOST_INCLUDE_PATH := $(BOOST_DIR)/include
-BOOST_LIB_PATH := $(BOOST_DIR)/lib
+BOOST_DIR := $(CURDIR)/boost_1_68_0
+BOOST_INCLUDE_PATH := $(BOOST_DIR)
+BOOST_BUILD_PATH := $(BOOST_DIR)/build
+BOOST_LIB_PATH := $(BOOST_BUILD_PATH)/lib
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
@@ -152,7 +153,12 @@ OBJS= \
     obj/zerocoin/SpendMetaData.o \
     obj/zerocoin/ZeroTest.o
 
-all: ecoind
+all: boost ecoind 
+
+boost:
+ifeq (,$(wildcard $(BOOST_DIR)/b2))
+	cd $(BOOST_DIR) && ./bootstrap.sh --prefix=$(BOOST_BUILD_PATH) && ./b2 && ./b2 install
+endif
 
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
@@ -193,7 +199,7 @@ obj/zerocoin/%.o: zerocoin/%.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-ecoind: $(OBJS:obj/%=obj/%)
+ecoind: $(OBJS:obj/%=obj/%) 
 	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
 
 clean:
@@ -203,5 +209,11 @@ clean:
 	-rm -f obj/*.P
 	-rm -f obj/zerocoin/*.P
 	-rm -f obj/build.h
+	-rm -f $(BOOST_BUILD_PATH)
+	-rm -f $(BOOST_DIR)/b2
+	-rm -f $(BOOST_DIR)/bin.v2
+	-rm -f $(BOOST_DIR)/project-config.jam
+	-rm -f $(BOOST_DIR)/stage
+
 
 FORCE:


### PR DESCRIPTION
The current prod code provides the boost 1.68.0 source code right inside the repo, probably, because ecoin currently only is compatible with that version.

This PR allows to build boost with that provided version, and suggests some correspondent updates to the docs.

I am aware that there are many ways to go about this, and this may not be the perfect one.
In fact, building the libs locally results in the dynamic linked libraries being placed in non-standard directories.
This is why this PR suggests to just use `LD_LIBRARY_PATH=... ./ecoind` when executing, after building ecoind.
Alternatively, the libraries could be copied to the system directories, which would require root rights.

I have not been able to find out if there is a way to link the libs directly to the binary, so that the `LD_LIBRARY_PATH` setting is not required, without copying to the system libs and without root rights.