### PR TITLE
fix: sync DISPLAY_VERSION with CLIENT_VERSION (0.4→0.7)

### DIFF
--- a/ecoin/src/version.h
+++ b/ecoin/src/version.h
@@ -49,7 +49,7 @@ static const int BIP0031_VERSION = 69999;
 static const int MEMPOOL_GD_VERSION = 70000;
 
 #define DISPLAY_VERSION_MAJOR       0
-#define DISPLAY_VERSION_MINOR       4
+#define DISPLAY_VERSION_MINOR       7
 #define DISPLAY_VERSION_REVISION    5
 #define DISPLAY_VERSION_BUILD       7
 


### PR DESCRIPTION
## Bug

`DISPLAY_VERSION_MINOR` in `src/version.h` was still set to `4` while `clientversion.h` was correctly updated to `7`. 

This caused `ecoind` to identify itself as `v0.4.5.7-ga-beta` to the network instead of `v0.7.5.7-ga-beta`.

## Impact

- Nodes compiled from the current source report the wrong version to the network
- Chain synchronization stalls at early blocks (observed stuck at block 67 while network is at 10,063+)
- Peers running Ikujam 0.7.5.7 may reject connections from nodes reporting 0.4.x

## Fix

One-line change: `DISPLAY_VERSION_MINOR 4` → `DISPLAY_VERSION_MINOR 7` in `src/version.h` to match `clientversion.h`.

Tested on Debian 12 (kernel 6.17), compiled and verified: node now reports `v0.7.5.7-ga-beta` and syncs correctly with the network.

